### PR TITLE
Minor code style fixes

### DIFF
--- a/lib/Client/Options/Facets/FacetORGroup.php
+++ b/lib/Client/Options/Facets/FacetORGroup.php
@@ -48,7 +48,7 @@ class FacetORGroup
     }
 
     /**
-     * @param Facet[] $facets
+     * @param Facet ...$facets
      * @return $this
      */
     public function addFacets(Facet ...$facets): self
@@ -62,7 +62,7 @@ class FacetORGroup
     /**
      * Add multiple facets of one type (e.g. multiple Minecraft versions or loaders)
      * @param FacetType $type
-     * @param string[] $values
+     * @param string ...$values
      * @return $this
      */
     public function addMultiple(FacetType $type, ...$values): self

--- a/lib/Client/Options/Facets/FacetORGroup.php
+++ b/lib/Client/Options/Facets/FacetORGroup.php
@@ -20,7 +20,7 @@ class FacetORGroup
     }
 
     /**
-     * @return array
+     * @return Facet[]
      */
     public function getFacets(): array
     {
@@ -28,7 +28,7 @@ class FacetORGroup
     }
 
     /**
-     * @param array $facets
+     * @param Facet[] $facets
      * @return $this
      */
     public function setFacets(array $facets): self


### PR DESCRIPTION
Unfortunately [PSR-5](https://github.com/php-fig/fig-standards/blob/master/proposed/phpdoc.md) does not suggest how to document variable length arguments in PHPDoc.
[This discussion](https://youtrack.jetbrains.com/issue/WI-29429) (and PHPStorm in general) suggests to use this syntax:
```php
/**
 * @param Facet ...$facets
 */
public function addFacets(Facet ...$facets)
```